### PR TITLE
Add ssHattrick

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,6 +94,7 @@ Aside from those listed here, many other apps and libraries can be easily be fou
 - [wordl](https://github.com/palerdot/wordl-rs) - Terminal-based Wordle game. Web like experience with keyboard hints and guess reveal animations.
 - [Rebels in the sky](https://github.com/ricott1/rebels-in-the-sky) - P2P terminal game about spacepirates playing basketball across the galaxy.
 - [enimtui](https://codeberg.org/tranzystorekk/enimtui) - Terminal-based minesweeper knockoff.
+- [ssHattrick](https://github.com/ricott1/sshattrick) - Play Hattrick in your terminal over SSH. 
 
 ### 🚀 Productivity and Utilities
 


### PR DESCRIPTION
Add ssHattrick, another terminal game :) to be played over ssh. You can just try it at `ssh frittura.org -p 2020`.