### PR TITLE
Add otree

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,6 +129,7 @@ Aside from those listed here, many other apps and libraries can be easily be fou
 - [synd](https://github.com/ymgyt/syndicationd) - A TUI feed viewer.
 - [btlescan](https://github.com/ztroop/btlescan) - Bluetooth Low Energy (BTLE) scanner and GATT viewer.
 - [wiper](https://github.com/ikebastuz/wiper) - Disk space analyzer and cleanup tool.
+- [otree](https://github.com/fioncat/otree) - A command line tool to view objects (json/yaml/toml) in TUI tree widget.
 
 ### 🎼 Music and Media
 


### PR DESCRIPTION
[otree](https://github.com/fioncat/otree) is a command line tool to view objects (json/yaml/toml) in TUI tree widget.

![screenshot](https://raw.githubusercontent.com/fioncat/otree/main/assets/screenshot.png)

Mainly based on https://github.com/EdJoPaTo/tui-rs-tree-widget.

I developed this to better view `yaml` files, since they usually have very deep levels.

