### PR TITLE
Add `tgt`

### DIFF
--- a/README.md
+++ b/README.md
@@ -155,6 +155,7 @@ Aside from those listed here, many other apps and libraries can be easily be fou
 - [tabiew](https://github.com/shshemi/tabiew) - A lightweight TUI app to view and query CSV files.
 - [taskwarrior-tui](https://github.com/kdheepak/taskwarrior-tui) - TUI for the Taskwarrior command-line task manager.
 - [td](https://github.com/holly-hacker/td) - A graph-based TUI to-do app.
+- [tgt](https://github.com/FedericoBruzzone/tgt) - A TUI for Telegram written in Rust.
 - [thesaurust](https://github.com/QuietPigeon2001/thesaurust) - A terminal-based dictionary app.
 - [tickrs](https://github.com/tarkah/tickrs) - Stock market ticker in the terminal.
 - [todolist-rust](https://github.com/ebubekirgungor/todolist-rust) - A terminal-based simple to-do app.


### PR DESCRIPTION
Add tgt TUI application to "Productivity and Utilities" section.

[tgt](https://github.com/FedericoBruzzone/tgt) is a terminal user interface for Telegram, written in Rust and Ratatui.